### PR TITLE
WIP-0001: update references to community channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WIPs
 __Witnet Improvement Proposals__ (WIPs) are documents proposing, specifying and standardizing new protocol features, processes and methods in the Witnet community.
 
-People wishing to submit WIPs, first should propose their idea or document to the [Witnet community Gitter chat room](https://gitter.im/witnet/community). After discussion, please open a Pull Request to this repository. After copy-editing and acceptance, it will be published here.
+People wishing to submit WIPs, first should propose their idea or document to the [Witnet community Discord][discord]. After discussion, please open a Pull Request to this repository. After copy-editing and acceptance, it will be published here.
 
 This repository is maintained by Witnet Foundation. We are fairly liberal with approving WIPs, and try not to be too involved in decision making on behalf of the community. The exception would be the very rare cases of dispute resolution when a decision is contentious and cannot be agreed upon. In those cases, the conservative option will always be preferred.
 
@@ -9,5 +9,7 @@ Having a WIP here does not make it a formally accepted standard until its status
 
 | Number | Layer | Title | Owner | Type | Status |
 |:------:|:-----:|:-----------:|:----------------------------:|:-------:|:--------:|
-| [1](wip-0001.md) |  | WIP process | [Adán SDPC](https://github.com/aesedepece) | Process | Accepted |
+| [1](wip-0001.md) |  | WIP process | [Adán SDPC](https://github.com/aesedepece) | Process | Final |
 | [2](wip-0002.md) | Consensus (hard fork) | Collateralization of Witnessing Activity | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Proposed |
+
+[discord]: https://discord.gg/X4uurfP

--- a/wip-0001.md
+++ b/wip-0001.md
@@ -4,7 +4,7 @@
   Author: Adán SDPC <adan@witnet.foundation>
   Comments-Summary: No comments yet.
   Comments-URI: https://github.com/witnet/wips/wiki/Comments:WIP-0001
-  Status: Accepted
+  Status: Final
   Type: Process
   Created: 2018-02-11
   License: BSD-2-Clause
@@ -28,18 +28,18 @@ The WIP process begins with a new idea for Witnet. Each potential WIP must have 
 Small enhancements or patches to a particular piece of software often don't require standardisation between multiple projects; these don't need a WIP and should be injected into the relevant project-specific development workflow with a patch submission to the applicable issue tracker.
 Additionally, many ideas have been brought forward for changing Witnet that have been rejected for various reasons.
 The first step should be to search past discussions to see if an idea has been considered before, and if so, what issues arose in its progression.
-After investigating past work, the best way to proceed is by posting about the new idea to the [Witnet community Gitter chat room](https://gitter.im/witnet/community).
+After investigating past work, the best way to proceed is by posting about the new idea to the [Witnet community Discord server][discord].
 
 Vetting an idea publicly before going as far as writing a WIP is meant to save both the potential author and the wider community time.
 Asking the Witnet community first if an idea is original helps prevent too much time being spent on something that is guaranteed to be rejected based on prior discussions (searching the internet does not always do the trick).
 It also helps to make sure the idea is applicable to the entire community and not just the author. Just because an idea sounds good to the author does not mean it will work for most people in most areas where Witnet is used.
 
-Once the champion has asked the Witnet community as to whether an idea has any chance of acceptance, a draft WIP should be presented to the [Witnet community Gitter chat room](https://gitter.im/witnet/community).
+Once the champion has asked the Witnet community as to whether an idea has any chance of acceptance, a draft WIP should be presented to the [Witnet community Discord chat server][discord].
 This gives the author a chance to flesh out the draft WIP to make it properly formatted, of high quality, and to address additional concerns about the proposal.
-Following a discussion, the proposal should be submitted to the [WIPs git repository](https://github.com/witnet/WIPs) as a pull request.
+Following a discussion, the proposal should be submitted to the [WIPs git repository][WIPs] as a pull request.
 This draft must be written in WIP style as described below, and named with an alias such as "WIP-champion-feature" until the editor has assigned it a WIP number (authors MUST NOT self-assign WIP numbers).
 
-WIP authors are responsible for collecting community feedback on both the initial idea and the WIP before submitting it for review. However, wherever possible, long open-ended discussions should be avoided. Strategies to keep the discussions efficient include: setting up a separate chat room or mailing list for the topic, having the WIP author accept private comments in the early design phases, setting up a wiki page or git repository, etc. WIP authors should use their discretion here.
+WIP authors are responsible for collecting community feedback on both the initial idea and the WIP before submitting it for review. However, wherever possible, long open-ended discussions should be avoided. Strategies to keep the discussions efficient include: setting up a separate chat room or channel for the topic, having the WIP author accept private comments in the early design phases, setting up a wiki page or git repository, etc. WIP authors should use their discretion here.
 
 It is highly recommended that a single WIP contain a single key proposal or new idea. The more focused the WIP, the more successful it tends to be. If in doubt, split your WIP into several well-focused ones.
 
@@ -69,14 +69,14 @@ For each new WIP that comes in an editor does the following:
 
 * Read the WIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted.
 * The title should accurately describe the content.
-* The WIP draft must have been sent to the Witnet development mailing list for discussion.
+* The WIP draft must have been sent to the Witnet development community channels for discussion.
 * Motivation and backward compatibility (when applicable) must be addressed.
 * The defined Layer header must be correctly assigned for the given specification.
 * Licensing terms must be acceptable for WIPs.
 
 If the WIP isn't ready, the editor will send it back to the author for revision, with specific instructions.
 
-Once the WIP is ready for the repository it should be submitted as a "pull request" to the [WIPs git repository](https://github.com/Witnet/WIPs ) where it may get further feedback.
+Once the WIP is ready for the repository it should be submitted as a "pull request" to the [WIPs git repository][WIPs] where it may get further feedback.
 
 The WIP editor will:
 
@@ -84,7 +84,7 @@ The WIP editor will:
 
 * Merge the pull request when it is ready.
 
-* List the WIP in [README.me].
+* List the WIP in [README.md](README.md).
 
 The WIP editors are intended to fulfill administrative and editorial responsibilities. The WIP editors monitor WIP changes, and update WIP headers as appropriate.
 
@@ -96,11 +96,11 @@ WIPs should be written in Markdown format.
 
 Each WIP should have the following parts:
 
-* Preamble -- Headers containing metadata about the WIP ([[#WIP header preamble|see below]]).
+* Preamble -- Headers containing metadata about the WIP ([see below](#WIP header preamble)).
 
 * Abstract -- A short (~200 word) description of the technical issue being addressed.
 
-* Copyright -- The WIP must be explicitly licensed under acceptable copyright terms ([[#WIP licensing|see below]]).
+* Copyright -- The WIP must be explicitly licensed under acceptable copyright terms ([see below](#WIP licensing)).
 
 * Specification -- The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Witnet platforms.
 
@@ -130,7 +130,7 @@ Each WIP must begin with an RFC 822 style header preamble. The headers must appe
   Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
   License: <abbreviation for approved license(s)>
 * License-Code: <abbreviation for code under different approved license(s)>
-* Post-History: <dates of postings to Witnet mailing list, or link to thread in mailing list archive>
+* Post-History: <dates of postings to Witnet community channels, or link to thread in such channels>
 * Requires: <WIP number(s)>
 * Replaces: <WIP number>
 * Superseded-By: <WIP number>
@@ -145,13 +145,13 @@ The format of the Author header value must be
 
 If there are multiple authors, each should be on a separate line following RFC 2822 continuation line conventions.
 
-While a WIP is in private discussions (usually during the initial Draft phase), a Discussions-To header will indicate the community discussion channels or URL where the WIP is being discussed. No Discussions-To header is necessary if the WIP is being discussed privately with the author, or on the Witnet community Gitter chat room.
+While a WIP is in private discussions (usually during the initial Draft phase), a Discussions-To header will indicate the community discussion channels or URL where the WIP is being discussed. No Discussions-To header is necessary if the WIP is being discussed privately with the author, or on the Witnet community Discord server.
 
 The Type header specifies the type of WIP: Standards Track, Informational, or Process.
 
-The Created header records the date that the WIP was assigned a number, while Post-History is used to record when new versions of the WIP are posted to Witnet mailing lists.
+The Created header records the date that the WIP was assigned a number, while Post-History is used to record when new versions of the WIP are posted to Witnet community channels.
 Dates should be in yyyy-mm-dd format, e.g. 2001-08-14.
-Post-History is permitted to be a link to a specific thread in a mailing list archive.
+Post-History is permitted to be a link to a specific thread in a community channel.
 
 WIPs may have a Requires header, indicating the WIP numbers that this WIP depends on.
 
@@ -184,11 +184,11 @@ A WIP may only change status from Draft (or Rejected) to Proposed, when the auth
 
 WIPs should be changed from Draft or Proposed status, to Rejected status, upon request by any person, if they have not made progress in three years. Such a WIP may be changed to Draft status if the champion provides revisions that meaningfully address public criticism of the proposal, or to Proposed status if it meets the criteria required as described in the previous paragraph.
 
-An Proposed WIP may progress to Final only when specific criteria reflecting real-world adoption has occurred. This is different for each WIP depending on the nature of its proposed changes, which will be expanded on below. Evaluation of this status change should be objectively verifiable, and/or be discussed on the development mailing list.
+An Proposed WIP may progress to Final only when specific criteria reflecting real-world adoption has occurred. This is different for each WIP depending on the nature of its proposed changes, which will be expanded on below. Evaluation of this status change should be objectively verifiable, and/or be discussed on the appropriate development community channel.
 
 When a Final WIP is no longer relevant, its status may be changed to Replaced or Obsolete (which is equivalent to Replaced). This change must also be objectively verifiable and/or discussed.
 
-A process WIP may change status from Draft to Active when it achieves rough consensus on the community discussion channels. Such a proposal is said to have rough consensus if it has been open to discussion on the development mailing list for at least one month, and no person maintains any unaddressed substantiated objections to it. Addressed or obstructive objections may be ignored/overruled by general agreement that they have been sufficiently addressed, but clear reasoning must be given in such circumstances.
+A process WIP may change status from Draft to Active when it achieves rough consensus on the community discussion channels. Such a proposal is said to have rough consensus if it has been open to discussion on the appropriate development community channels for at least one month, and no person maintains any unaddressed substantiated objections to it. Addressed or obstructive objections may be ignored/overruled by general agreement that they have been sufficiently addressed, but clear reasoning must be given in such circumstances.
 
 ## WIP comments
 
@@ -197,19 +197,9 @@ A process WIP may change status from Draft to Active when it achieves rough cons
 Each WIP should, in its preamble, link to a public wiki page with a summary tone of the comments on that page.
 Reviewers of the WIP who consider themselves qualified, should post their own comments on this wiki page.
 The comments page should generally only be used to post final comments for a completed WIP.
-If a WIP is not yet completed, reviewers should instead post on the applicable development mailing list thread to allow the WIP author(s) to address any concerns or problems pointed out by the review.
+If a WIP is not yet completed, reviewers should instead post on the applicable development community channel thread to allow the WIP author(s) to address any concerns or problems pointed out by the review.
 
 Some WIPs receive exposure outside the development community prior to completion, and other WIPs might not be completed at all. To avoid a situation where critical WIP reviews may go unnoticed during this period, reviewers may, at their option, still post their review on the comments page, provided they first post it to the community discussion channels and plan to later remove or revise it as applicable based on the completed version. Such revisions should be made by editing the previous review and updating the timestamp. Reviews made prior to the complete version may be removed if they are no longer applicable and have not been updated in a timely manner (eg, within one month).
-
-Pages must be named after the full WIP number (eg, "WIP 0001") and placed in the "Comments" namespace.
-For example, the link for WIP 1 will be https://github.com/Witnet/WIPs/wiki/Comments:WIP-0001 .
-
-Comments posted to this wiki should use the following format:
-
-    <Your opinion> --<Your name>, <Date of posting, as YYYY-MM-DD>
-
-WIPs may also choose to list a second forum for WIP comments, in addition to the WIPs wiki.
-In this case, the second forum's URI should be listed below the primary wiki's URI.
 
 After some time, the WIP itself may be updated with a summary tone of the comments.
 Summary tones may be chosen from the following, but this WIP does not intend to cover all possible nuances and other summaries may be used as needed:
@@ -315,3 +305,6 @@ Why is Public Domain not acceptable for WIPs?
 
 * Bitcoin's [BIP-0002](BIP-0002), on which this WIP is based.
 * [RFC 7282: On Consensus and Humming in the IETF](https://tools.ietf.org/html/rfc7282)
+
+[discord]: https://discord.gg/X4uurfP
+[WIPs]: https://github.com/witnet/WIPs


### PR DESCRIPTION
Since the date in which [WIP-0001] was first published (2018-02-11), the Witnet community has made noticeable changes in its preferred choice of communication channels. Namely, development coordination and discussions have been moved into GitHub and Discord .

This PR updates [WIP-0001] and the [README] file to reflect a more realistic expectation in terms of communication flows when discussing WIPs.

[WIP-0001]: https://github.com/witnet/WIPs/blob/master/wip-0001.md
[README]: https://github.com/witnet/WIPs/blob/master/README.md