### PR TITLE
WIP-0008: move to Final stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Having a WIP here does not make it a formally accepted standard until its status
 | [5](wip-0005.md) | Consensus (soft fork) | ARS merkelization | [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Proposed |
 | [6](wip-0006.md) | Consensus (hard fork) | Coexistence of BLS and Secp256k1 keys | [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Proposed |
 | [7](wip-0007.md) | Consensus (hard fork) | Block weight | [Mario Cao](https://github.com/mariocao) and [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Final |
-| [8](wip-0008.md) | Consensus (hard fork) | Limits on data request concurrency | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Draft |
+| [8](wip-0008.md) | Consensus (hard fork) | Limits on data request concurrency | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Final |
 | [9](wip-0009.md) | Consensus (hard fork) | Adjust mining probability | [Mario Cao](https://github.com/mariocao) and [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Proposed |
 
 [discord]: https://discord.gg/X4uurfP

--- a/wip-0008.md
+++ b/wip-0008.md
@@ -4,7 +4,7 @@
     Title: Limits on data request concurrency
     Author: Adán SDPC <adan@witnet.foundation>
     Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-    Status: Draft
+    Status: Final
     Type: Standards Track
     Created: 2021-01-12
     License: BSD-2-Clause


### PR DESCRIPTION
As these changes have been enforced on the network by witnet-rust
~1.1.0 since Jan 22 causing no network disruption or community
backlash whatsoever.