### PR TITLE
WIP-0009: move to Final stage

### DIFF
--- a/wip-0009.md
+++ b/wip-0009.md
@@ -5,7 +5,7 @@
     Authors: Mario Cao <mario@witnet.foundation>
              Gorka Irazoqui <gorka.irazoki@gmail.com>
     Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-    Status: Proposed
+    Status: Final
     Type: Standards Track
     Created: 2021-01-26
     License: BSD-2-Clause
@@ -90,7 +90,9 @@ The business logic described in the specification has been implemented in [witne
 
 ## Adoption Plan
 
-The changes proposed herein have been already implemented in [witnet-rust] and the activation of the new consensus rule is scheduled as a community-coordinated hard fork to take place on March 16 2021 at 9 am UTC, as proposed by [pull request #1829][witnet/witnet-rust#1829] and [widely announced to the community][announcement] in a timely manner.
+The changes proposed herein have been already implemented in [witnet-rust] and the activation of the new consensus rule is scheduled as a community-coordinated hard fork to take place on March 23 2021 at 9 am UTC.
+
+Initially, the activation was [announced][announcement-wip0009] and proposed by [pull request #1829][witnet/witnet-rust#1829] for March 16 February 2021 at 9 am UTC. However, the adoption has been delayed one week due to the [network disruptions][announcement-network-disruption] occurred on February 20 2021.
 
 
 ## Acknowledgments
@@ -100,7 +102,8 @@ This proposal has been cooperatively discussed and devised by many individuals f
 Special thanks to [Luis Rubio][lrubiorod] for the reference implementation in Rust.
 
 
-[announcement]: https://medium.com/witnet/359ff11dfdbe
+[announcement-wip0009]: https://medium.com/witnet/359ff11dfdbe
+[announcement-network-disruption]: https://medium.com/witnet/9a0bdfd0325e
 [DoS]: https://en.wikipedia.org/wiki/Denial-of-service_attack
 [lrubiorod]: https://github.com/lrubiorod
 [RandPoE]: https://github.com/witnet/research/blob/master/reputation/docs/randpoe.md


### PR DESCRIPTION
> Initially, the activation was [announced][announcement-wip0009] and proposed by [pull request #1829][witnet/witnet-rust#1829] for March 16 February 2021 at 9 am UTC. However, the adoption has been delayed one week due to the [network disruptions][announcement-network-disruption] occurred on February 20 2021.

[announcement-wip0009]: https://medium.com/witnet/359ff11dfdbe
[announcement-network-disruption]: https://medium.com/witnet/9a0bdfd0325e
[witnet/witnet-rust#1829]: https://github.com/witnet/witnet-rust/issues/1829