### PR TITLE
wip-0009,0011,0012: propose activation date on April 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Having a WIP here does not make it a formally accepted standard until its status
 | [8](wip-0008.md) | Consensus (hard fork) | Limits on data request concurrency | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Final |
 | [9](wip-0009.md) | Consensus (hard fork) | Adjust mining probability | [Mario Cao](https://github.com/mariocao) and [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Proposed |
 | [10](wip-0010.md) |  | Feb 2021 Chain Fork Post-Mortem | [The witnet-rust developers](https://github.com/witnet/witnet-rust/graphs/contributors) | Informational | Proposed |
-| [11](wip-0011.md) | Consensus (hard fork) | Improve consistency and availability of superblock voting protocol | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Draft |
-| [12](wip-0012.md) | Consensus (hard fork) | Set minimum mining difficulty  | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Draft |
+| [11](wip-0011.md) | Consensus (hard fork) | Improve consistency and availability of superblock voting protocol | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Proposed |
+| [12](wip-0012.md) | Consensus (hard fork) | Set minimum mining difficulty  | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Proposed |
 
 [discord]: https://discord.gg/X4uurfP

--- a/wip-0009.md
+++ b/wip-0009.md
@@ -90,8 +90,9 @@ The business logic described in the specification has been implemented in [witne
 
 ## Adoption Plan
 
-Initially, the activation was [announced][announcement-wip0009] and proposed by [pull request #1829][witnet/witnet-rust#1829] for March 16 February 2021 at 9 am UTC. However, the adoption has been delayed undefinetely due to the [network disruptions][announcement-network-disruption] occurred on February 20 2021.
+Initially, the activation was [announced][announcement-wip0009] and proposed by [pull request #1829][witnet/witnet-rust#1829] for March 16 2021 at 9am UTC. However, the adoption was later delayed due to the [network disruptions][announcement-network-disruption] occurred on February 20 2021.
 
+A new activation date is proposed for April 28 2021 at 9am UTC, in expectation that the protocol improvements described herein jointly enter into force with the related [WIP-0011] and [WIP-0012].
 
 ## Acknowledgments
 
@@ -99,7 +100,8 @@ This proposal has been cooperatively discussed and devised by many individuals f
 
 Special thanks to [Luis Rubio][lrubiorod] for the reference implementation in Rust.
 
-
+[WIP-0011]: /wip-0011.md
+[WIP-0012]: /wip-0012.md
 [announcement-wip0009]: https://medium.com/witnet/359ff11dfdbe
 [announcement-network-disruption]: https://medium.com/witnet/9a0bdfd0325e
 [DoS]: https://en.wikipedia.org/wiki/Denial-of-service_attack

--- a/wip-0011.md
+++ b/wip-0011.md
@@ -163,7 +163,7 @@ A reference implementation for the proposed protocol improvements can be found a
 
 ## Adoption Plan
 
-An adoption plan will be proposed upon moving this document from the _Draft_ stage to the _Proposed_ stage.
+An activation date is proposed for April 28 2021 at 9am UTC, in expectation that the protocol improvements described herein jointly enter into force with the related [WIP-0009] and [WIP-0012].
 
 ## Acknowledgements
 
@@ -174,7 +174,9 @@ Special thanks to:
 - [Tomasz Polaczyk][tmpolaczyk] for [running the numbers][numbers] on Jupiter Notebook.
 
 
+[WIP-0009]: /wip-0009.md
 [WIP-0010]: /wip-0010.md
+[WIP-0012]: /wip-0012.md
 [Issue 1467]: https://github.com/witnet/witnet-rust/issues/1467
 [modulo bias]: https://research.kudelskisecurity.com/2020/07/28/the-definitive-guide-to-modulo-bias-and-how-to-avoid-it/
 [2nd-hf]: https://github.com/witnet/witnet-rust/tree/second_hard_fork

--- a/wip-0012.md
+++ b/wip-0012.md
@@ -98,7 +98,7 @@ A reference implementation for the proposed protocol improvements can be found a
 
 ## Adoption Plan
 
-An adoption plan will be proposed upon moving this document from the _Draft_ stage to the _Proposed_ stage.
+An activation date is proposed for April 28 2021 at 9am UTC, in expectation that the protocol improvements described herein jointly enter into force with the related [WIP-0009] and [WIP-0011].
 
 ## Acknowledgements
 


### PR DESCRIPTION
I'm proposing a joint activation of [WIP-0009], [WIP-0011] and [WIP-0012] on April 28 2021 at 9am UTC.

Any discussions on the documents can be conducted here or on our Discord [#dev-general channel][discord]. If there's consensus around these documents, we shall push the hard forking `witnet-rust 1.2.0` release by April 20.  

[WIP-0009]: https://github.com/witnet/WIPs/blob/master/wip-0009.md
[WIP-0011]: https://github.com/witnet/WIPs/blob/master/wip-0011.md
[WIP-0012]: https://github.com/witnet/WIPs/blob/master/wip-0012.md
[discord]: https://discord.gg/X4uurfP