### PR TITLE
wip-001[0123]: promote to final

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Having a WIP here does not make it a formally accepted standard until its status
 | [6](wip-0006.md) | Consensus (hard fork) | Coexistence of BLS and Secp256k1 keys | [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Proposed |
 | [7](wip-0007.md) | Consensus (hard fork) | Block weight | [Mario Cao](https://github.com/mariocao) and [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Final |
 | [8](wip-0008.md) | Consensus (hard fork) | Limits on data request concurrency | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Final |
-| [9](wip-0009.md) | Consensus (hard fork) | Adjust mining probability | [Mario Cao](https://github.com/mariocao) and [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Proposed |
+| [9](wip-0009.md) | Consensus (hard fork) | Adjust mining probability | [Mario Cao](https://github.com/mariocao) and [Gorka Irazoqui](https://github.com/girazoki) | Standards Track | Final |
 | [10](wip-0010.md) |  | Feb 2021 Chain Fork Post-Mortem | [The witnet-rust developers](https://github.com/witnet/witnet-rust/graphs/contributors) | Informational | Final |
-| [11](wip-0011.md) | Consensus (hard fork) | Improve consistency and availability of superblock voting protocol | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Proposed |
-| [12](wip-0012.md) | Consensus (hard fork) | Set minimum mining difficulty  | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Proposed |
-| [13](wip-0013.md) |  | Apr 2021 Chain Fork Post-Mortem | [The witnet-rust developers](https://github.com/witnet/witnet-rust/graphs/contributors) | Informational | Proposed |
+| [11](wip-0011.md) | Consensus (hard fork) | Improve consistency and availability of superblock voting protocol | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Final |
+| [12](wip-0012.md) | Consensus (hard fork) | Set minimum mining difficulty  | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Final |
+| [13](wip-0013.md) |  | Apr 2021 Chain Fork Post-Mortem | [The witnet-rust developers](https://github.com/witnet/witnet-rust/graphs/contributors) | Informational | Final |
 
 [discord]: https://discord.gg/X4uurfP

--- a/wip-0010.md
+++ b/wip-0010.md
@@ -3,7 +3,7 @@
   Title: Feb 2021 Chain Fork Post-Mortem
   Author: The witnet-rust developers <devs@witnet.io>
   Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-  Status: Proposed
+  Status: Final
   Type: Informational
   Created: 2021-02-22
   License: PD

--- a/wip-0011.md
+++ b/wip-0011.md
@@ -4,7 +4,7 @@
     Title: Improve consistency and availability of superblock voting protocol
     Authors: Adán SDPC <adan@witnet.foundation>        
     Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-    Status: Draft
+    Status: Final
     Type: Standards Track
     Created: 2021-04-06
     License: BSD-2-Clause

--- a/wip-0012.md
+++ b/wip-0012.md
@@ -4,7 +4,7 @@
     Title: Set minimum mining difficulty 
     Authors: Adán SDPC <adan@witnet.foundation>
     Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-    Status: Draft
+    Status: Final
     Type: Standards Track
     Created: 2021-04-08
     License: BSD-2-Clause

--- a/wip-0013.md
+++ b/wip-0013.md
@@ -3,7 +3,7 @@
   Title: Apr 2021 Chain Fork Post-Mortem
   Author: The witnet-rust developers <devs@witnet.io>
   Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-  Status: Proposed
+  Status: Final
   Type: Informational
   Created: 2021-04-24
   License: PD


### PR DESCRIPTION
Promote the following WIPs to Final, as the protocol improvements proposed therein have been active on mainnet for days with no major consensus or network disruption:
- WIP-0010
- WIP-0011
- WIP-0012
- WIP-0013