### PR TITLE
Promote WIP-0014 (TAPI) to `Proposed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Having a WIP here does not make it a formally accepted standard until its status
 | [11](wip-0011.md) | Consensus (hard fork) | Improve consistency and availability of superblock voting protocol | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Final |
 | [12](wip-0012.md) | Consensus (hard fork) | Set minimum mining difficulty  | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Final |
 | [13](wip-0013.md) |  | Apr 2021 Chain Fork Post-Mortem | [The witnet-rust developers](https://github.com/witnet/witnet-rust/graphs/contributors) | Informational | Final |
-| [14](wip-0014.md) | Consensus (hard fork) | Threshold Activation of Protocol Improvements  | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Draft |
+| [14](wip-0014.md) | Consensus (hard fork) | Threshold Activation of Protocol Improvements  | [Adán SDPC](https://github.com/aesedepece) | Standards Track | Proposed |
 | [15](wip-0015.md) | Consensus (hard fork) | Amendment to WIP-0007  | [Mario Cao](https://github.com/mariocao) | Standards Track | Final |
 | [16](wip-0016.md) | Consensus (hard fork) | Set minimum data request mining difficulty  | [Mario Cao](https://github.com/mariocao) | Standards Track | Draft |
 

--- a/README.md
+++ b/README.md
@@ -26,4 +26,14 @@ Having a WIP here does not make it a formally accepted standard until its status
 | [15](wip-0015.md) | Consensus (hard fork) | Amendment to WIP-0007  | [Mario Cao](https://github.com/mariocao) | Standards Track | Final |
 | [16](wip-0016.md) | Consensus (hard fork) | Set minimum data request mining difficulty  | [Mario Cao](https://github.com/mariocao) | Standards Track | Draft |
 
+## TAPI signals
+
+These are the bits currently being used for signaling support for and activating Witnet Improvement Proposals through
+the procedure set forth by [WIP-0014]: _Threshold Activation of Protocol Improvements (TAPI)_.
+
+| Bit position | WIP(s)            | First signaling epoch | State       |
+|:------------:|:-----------------:|:---------------------:|:-----------:|
+| 1            | [14](wip-0014.md) | `522240`              | `Signaling` |
+
 [discord]: https://discord.gg/X4uurfP
+[WIP-0014]: wip-0014.md

--- a/wip-0014.md
+++ b/wip-0014.md
@@ -279,4 +279,4 @@ This proposal has been cooperatively discussed and devised by many individuals f
 [WIP-0012]: https://github.com/witnet/WIPs/blob/master/wip-0012.md
 [witnet-rust]: https://github.com/witnet/witnet-rust
 [bit field]: https://en.wikipedia.org/wiki/Bit_field
-[tapi]: https://github.com/witnet/witnet-rust/tree/tapi
+[tapi]: https://github.com/witnet/witnet-rust/tree/tapi2

--- a/wip-0014.md
+++ b/wip-0014.md
@@ -83,8 +83,9 @@ let nth_is_supported = (signals & (1 << (n - 1))) != 0
 ```
 
 **(3)** The default value of `signals` is `0b00000000000000000000000000000001`. This default value implicitly
-signals support for all the features existing in the protocol before the adoption of this proposal. The `1.2.1`
-release of [witnet-rust] acts as a reference  what these implicit features are.
+signals support for all the features existing in the protocol before the adoption of this proposal, plus the protocol
+improvements described herein. The `1.2.3` release of [witnet-rust] acts as a reference  what these implicit features
+are.
 
 Assignment of each signaling bit position to specific protocol improvements is discussed later in *[Changes to WIP
  Process](#Changes-to-WIP-Process)*.

--- a/wip-0014.md
+++ b/wip-0014.md
@@ -4,7 +4,7 @@
   Title: Threshold Activation of Protocol Improvements
   Authors: Adán SDPC <adan@witnet.foundation>
   Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-  Status: Draft
+  Status: Proposed
   Type: Standards Track + Process
   Created: 2020-05-11
   License: BSD-2-Clause

--- a/wip-0014.md
+++ b/wip-0014.md
@@ -263,7 +263,10 @@ witnet-rust repository][tapi].
 
 ## Adoption Plan
 
-An adoption plan is in the making.
+An activation date is proposed for July 13 2021 at 9am UTC, that is, protocol epoch #522240.
+
+From the perspective of TAPI, the `first_signaling_epoch` for the base implicit signal (
+`0b00000000000000000000000000000001`) is also set to #522240. 
 
 ## Acknowledgments
 

--- a/wip-0014.md
+++ b/wip-0014.md
@@ -84,7 +84,7 @@ let nth_is_supported = (signals & (1 << (n - 1))) != 0
 
 **(3)** The default value of `signals` is `0b00000000000000000000000000000001`. This default value implicitly
 signals support for all the features existing in the protocol before the adoption of this proposal, plus the protocol
-improvements described herein. The `1.2.3` release of [witnet-rust] acts as a reference  what these implicit features
+improvements described herein. The `1.2.3` release of [witnet-rust] acts as a reference of what these implicit features
 are.
 
 Assignment of each signaling bit position to specific protocol improvements is discussed later in *[Changes to WIP
@@ -279,4 +279,4 @@ This proposal has been cooperatively discussed and devised by many individuals f
 [WIP-0012]: https://github.com/witnet/WIPs/blob/master/wip-0012.md
 [witnet-rust]: https://github.com/witnet/witnet-rust
 [bit field]: https://en.wikipedia.org/wiki/Bit_field
-[tapi]: https://github.com/witnet/witnet-rust/tree/tapi2
+[tapi]: https://github.com/witnet/witnet-rust/tree/tapi


### PR DESCRIPTION
This PR:
- proposes activation of WIP-0014 (TAPI) on July 13 2021 at 9am UTC, that is, protocol epoch #522240.
- introduces a table in README.md that will list the signaling bits of different TAPI upgrades, as mandated by WIP-0014 itself.

Close #60 