### PR TITLE
wip-0016: promote to `Proposed` state

### DIFF
--- a/wip-0016.md
+++ b/wip-0016.md
@@ -4,7 +4,7 @@
     Title: Set minimum data request mining difficulty
     Authors: Mario Cao <mario@witnet.foundation>
     Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-    Status: Draft
+    Status: Proposed
     Type: Standards Track
     Created: 2021-06-08
     License: BSD-2-Clause
@@ -187,7 +187,9 @@ A reference implementation for the proposed protocol improvements labeled as  **
 
 ## Adoption Plan
 
-An adoption plan will be proposed upon moving this document from the _Draft_ stage to the _Proposed_ stage.
+An activation date is proposed for July 13 2021 at 9am UTC, that is, protocol epoch #522240.
+
+From the perspective of TAPI, this proposal will be signaled along with the [WIP-0014]. This proposal adheres to the base implicit signal, and its first signaling epoch is also set to that of [WIP-0014].
 
 
 ## Acknowledgements
@@ -203,6 +205,7 @@ Special thanks to [Luis Rubio][lrubiorod] for double-checking the specification 
 [VRF]:  https://medium.com/witnet/c847edf123f7
 [WIP-0009]: /wip-0009.md
 [WIP-0012]: /wip-0012.md
+[WIP-0014]: /wip-0014.md
 [3rd-hf]: https://github.com/witnet/witnet-rust/tree/202106-recovery
 [lrubiorod]: https://github.com/lrubiorod
 [tmpolaczyk]: https://github.com/tmpolaczyk


### PR DESCRIPTION
> An activation date is proposed for July 13 2021 at 9am UTC, that is, protocol epoch #522240.

> From the perspective of TAPI, this proposal will be signaled along with the WIP-0014. The `first_signaling_epoch` for the base implicit signal (`0b00000000000000000000000000000001`) is also set to #522240. 