### PR TITLE
chore: mark WIPs 0020 and 0021 as Final

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ the procedure set forth by [WIP-0014]: _Threshold Activation of Protocol Improve
 |:------------:|:-------------------------------------------------------:|:---------------------:|:-----------:|
 | 0            | [14](wip-0014.md), [16](wip-0016.md)                    | `522240`              | `In force`  |
 | 1            | [17](wip-0017.md), [18](wip-0018.md), [19](wip-0019.md) | `656640`              | `In force`  |
-| 2            | [20](wip-0020.md), [21](wip-0021.md)                    | `1032960`             | `Signaling` |
+| 2            | [20](wip-0020.md), [21](wip-0021.md)                    | `1032960`             | `In force`  |
 
 [discord]: https://discord.gg/X4uurfP
 [WIP-0014]: wip-0014.md

--- a/wip-0020.md
+++ b/wip-0020.md
@@ -4,7 +4,7 @@
   Title: Support HTTP-POST in RADON
   Authors: Tomasz Polaczyk <tomasz@witnet.foundation>
   Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-  Status: Proposed
+  Status: Final
   Type: Standards Track
   Created: 2021-12-02
   License: BSD-2-Clause

--- a/wip-0021.md
+++ b/wip-0021.md
@@ -4,7 +4,7 @@
   Title: Add StringParseXMLMap to RADON operators
   Authors: Luis Rubio <luisr@witnet.foundation>
   Discussions-To: `#dev-general` channel on Witnet Community's Discord server
-  Status: Proposed
+  Status: Final
   Type: Standards Track
   Created: 2021-12-14
   License: BSD-2-Clause


### PR DESCRIPTION
As explained in the commit description, this PR moves WIPs 0020 and 0021 to their Final stage, as they have been live on the Witnet Mainnet for months.